### PR TITLE
Fixed: CopyOnWriteArraySet.iterator doesn't support remove

### DIFF
--- a/boundedqueue/src/main/java/io/bufferslayer/AsyncReporter.java
+++ b/boundedqueue/src/main/java/io/bufferslayer/AsyncReporter.java
@@ -11,7 +11,6 @@ import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import io.bufferslayer.OverflowStrategy.Strategy;
 import io.bufferslayer.internal.Component;
 import java.io.Flushable;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -176,14 +175,11 @@ public class AsyncReporter implements Reporter, Flushable, Component {
     }
   }
 
-  public int flushThreadCount() {
+  int flushThreadCount() {
     int c = 0;
-    for (Iterator<Thread> iter = flushThreads.iterator(); iter.hasNext(); ) {
-      if (iter.next().isAlive()) {
-        c++;
-      } else {
-        iter.remove();
-      }
+    for (Thread flushThread : flushThreads) {
+      if (flushThread.isAlive()) c++;
+      else flushThreads.remove(flushThread);
     }
     return c;
   }

--- a/boundedqueue/src/test/java/io/bufferslayer/AsyncReporterTest.java
+++ b/boundedqueue/src/test/java/io/bufferslayer/AsyncReporterTest.java
@@ -78,10 +78,14 @@ public class AsyncReporterTest {
         .build();
     reporter.report(newMessage(0));
 
+    assertEquals(1, reporter.flushThreadCount());
+
     countDown.await(50, TimeUnit.MILLISECONDS);
     // messageTimeout + flushThreadKeepalive
     Thread.sleep(TimeUnit.MILLISECONDS.toMillis(20));
     assertEquals(0, reporter.pendings.size());
+    assertEquals(0, reporter.flushThreadCount()); // should remove dead thread
+    assertEquals(0, reporter.flushThreads.size());
   }
 
   @Test


### PR DESCRIPTION
This would cause `java.lang.UnsupportedOperationException`