### PR TITLE
Make flush threads count configurable

### DIFF
--- a/benchmark/src/main/java/io/bufferslayer/AsyncReporterBenchmark.java
+++ b/benchmark/src/main/java/io/bufferslayer/AsyncReporterBenchmark.java
@@ -1,6 +1,5 @@
 package io.bufferslayer;
 
-import java.io.IOException;
 import java.util.concurrent.TimeUnit;
 import org.openjdk.jmh.annotations.AuxCounters;
 import org.openjdk.jmh.annotations.Benchmark;
@@ -15,7 +14,6 @@ import org.openjdk.jmh.annotations.OutputTimeUnit;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
-import org.openjdk.jmh.annotations.TearDown;
 import org.openjdk.jmh.annotations.Warmup;
 import org.openjdk.jmh.runner.Runner;
 import org.openjdk.jmh.runner.RunnerException;

--- a/boundedqueue/src/main/java/io/bufferslayer/QueueRecycler.java
+++ b/boundedqueue/src/main/java/io/bufferslayer/QueueRecycler.java
@@ -1,0 +1,44 @@
+package io.bufferslayer;
+
+import io.bufferslayer.Message.MessageKey;
+import java.util.LinkedList;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Created by guohang.bao on 2017/5/4.
+ * A recycler that manages {@link SizeBoundedQueue}'s lifecycle
+ */
+public interface QueueRecycler {
+
+  /**
+   * Get a queue by message key if exists otherwise create one
+   *
+   * @param key message key related to the queue
+   * @return the queue
+   */
+  SizeBoundedQueue getOrCreate(MessageKey key);
+
+  /**
+   * Lease a queue due to its priority
+   *
+   * @return queue with the highest priority at the moment
+   */
+  SizeBoundedQueue lease(long timeout, TimeUnit unit);
+
+  /**
+   * Put the queue back to recycler for others to use
+   *
+   * @param queue queue to return back
+   */
+  void recycle(SizeBoundedQueue queue);
+
+  /**
+   * Drop queues which exceed its keepalive
+   */
+  LinkedList<SizeBoundedQueue> shrink();
+
+  /**
+   * clear everything
+   */
+  void clear();
+}

--- a/boundedqueue/src/main/java/io/bufferslayer/ReporterProperties.java
+++ b/boundedqueue/src/main/java/io/bufferslayer/ReporterProperties.java
@@ -19,7 +19,8 @@ public class ReporterProperties {
   private String metrics = "noop";
   private Exporters metricsExporter = Exporters.noop;
   private long messageTimeoutNanos = TimeUnit.SECONDS.toNanos(1);
-  private long flushThreadKeepaliveNanos = TimeUnit.SECONDS.toNanos(60);
+  private long pendingKeepaliveNanos = TimeUnit.SECONDS.toNanos(60);
+  private int flushThreadCount = 5;
   private int bufferedMaxMessages = 100;
   private int pendingMaxMessages = 10000;
   private boolean strictOrder = false;
@@ -73,12 +74,21 @@ public class ReporterProperties {
     return this;
   }
 
-  public long getFlushThreadKeepaliveNanos() {
-    return flushThreadKeepaliveNanos;
+  public long getPendingKeepaliveNanos() {
+    return pendingKeepaliveNanos;
   }
 
-  public ReporterProperties setFlushThreadKeepaliveNanos(long flushThreadKeepalive, TimeUnit unit) {
-    this.flushThreadKeepaliveNanos = unit.toNanos(flushThreadKeepalive);
+  public ReporterProperties setPendingKeepaliveNanos(long pendingKeepalive, TimeUnit unit) {
+    this.pendingKeepaliveNanos = unit.toNanos(pendingKeepalive);
+    return this;
+  }
+
+  public int getFlushThreadCount() {
+    return flushThreadCount;
+  }
+
+  public ReporterProperties setFlushThreadCount(int flushThreadCount) {
+    this.flushThreadCount = flushThreadCount;
     return this;
   }
 
@@ -138,7 +148,8 @@ public class ReporterProperties {
         .senderExecutor(senderExecutor)
         .parallelismPerBatch(parallelismPerBatch)
         .messageTimeout(messageTimeoutNanos, TimeUnit.NANOSECONDS)
-        .flushThreadKeepalive(flushThreadKeepaliveNanos, TimeUnit.NANOSECONDS)
+        .pendingKeepalive(pendingKeepaliveNanos, TimeUnit.NANOSECONDS)
+        .flushThreadCount(flushThreadCount)
         .bufferedMaxMessages(bufferedMaxMessages)
         .pendingMaxMessages(pendingMaxMessages)
         .strictOrder(strictOrder)

--- a/boundedqueue/src/main/java/io/bufferslayer/SizeFirstQueueRecycler.java
+++ b/boundedqueue/src/main/java/io/bufferslayer/SizeFirstQueueRecycler.java
@@ -1,0 +1,132 @@
+package io.bufferslayer;
+
+import io.bufferslayer.Message.MessageKey;
+import io.bufferslayer.OverflowStrategy.Strategy;
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.Iterator;
+import java.util.LinkedList;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.PriorityBlockingQueue;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Created by guohang.bao on 2017/5/4.
+ */
+final class SizeFirstQueueRecycler implements QueueRecycler {
+
+  private static final Logger logger = LoggerFactory.getLogger(SizeFirstQueueRecycler.class);
+
+  final Map<MessageKey, SizeBoundedQueue> keyToQueue;
+  final Map<MessageKey, Long> keyToLastGet;
+
+  final PriorityBlockingQueue<SizeBoundedQueue> bySize;
+  final int pendingMaxMessages;
+  final Strategy overflowStrategy;
+  final long pendingKeepaliveNanos;
+
+  private final Lock lock = new ReentrantLock();
+
+  private static final Comparator<SizeBoundedQueue> SIZE_FIRST =
+      new Comparator<SizeBoundedQueue>() {
+        @Override
+        public int compare(SizeBoundedQueue q1, SizeBoundedQueue q2) {
+          return q2.count - q1.count;
+        }
+      };
+
+  SizeFirstQueueRecycler(int pendingMaxMessages, Strategy overflowStrategy,
+      long pendingKeepaliveNanos) {
+    this.keyToQueue = new ConcurrentHashMap<>();
+    this.keyToLastGet = new ConcurrentHashMap<>();
+
+    this.bySize = new PriorityBlockingQueue<>(16, SIZE_FIRST);
+    this.pendingMaxMessages = pendingMaxMessages;
+    this.overflowStrategy = overflowStrategy;
+    this.pendingKeepaliveNanos = pendingKeepaliveNanos;
+  }
+
+  private static long now() {
+    return System.nanoTime();
+  }
+
+  @Override
+  public SizeBoundedQueue getOrCreate(MessageKey key) {
+    SizeBoundedQueue queue = keyToQueue.get(key);
+    if (queue == null) {
+      // race condition initializing pending queue
+      try {
+        lock.lock();
+        queue = keyToQueue.get(key);
+        if (queue == null) {
+          queue = new SizeBoundedQueue(pendingMaxMessages, overflowStrategy);
+          keyToQueue.put(key, queue);
+          recycle(queue);
+        }
+      } finally {
+        lock.unlock();
+      }
+    }
+    keyToLastGet.put(key, now());
+    return queue;
+  }
+
+  @Override
+  public SizeBoundedQueue lease(long timeout, TimeUnit unit) {
+    try {
+      return bySize.poll(timeout, unit);
+    } catch (InterruptedException e) {
+      logger.error("Interrupted leasing queue.", e);
+      throw new RuntimeException(e);
+    }
+  }
+
+  @Override
+  public void recycle(SizeBoundedQueue queue) {
+    if (queue != null) {
+      bySize.offer(queue);
+    }
+  }
+
+  static Long getOrDefault(Map<MessageKey, Long> map, MessageKey key, Long defaultValue) {
+    Long v;
+    return (((v = map.get(key)) != null) || map.containsKey(key))
+        ? v
+        : defaultValue;
+  }
+
+  @Override
+  public LinkedList<SizeBoundedQueue> shrink() {
+    LinkedList<SizeBoundedQueue> result = new LinkedList<>();
+    Iterator<MessageKey> iterator = keyToLastGet.keySet().iterator();
+
+    while (iterator.hasNext()) {
+      MessageKey next = iterator.next();
+      if (now() - getOrDefault(keyToLastGet, next, now()) > pendingKeepaliveNanos) {
+        SizeBoundedQueue queue = keyToQueue.remove(next);
+        keyToLastGet.remove(next);
+        if (queue != null) {
+          bySize.remove(queue);
+          result.add(queue);
+        }
+      }
+    }
+    return result;
+  }
+
+  @Override
+  public void clear() {
+    keyToQueue.clear();
+    keyToLastGet.clear();
+    bySize.clear();
+  }
+
+  Collection<SizeBoundedQueue> elements() {
+    return keyToQueue.values();
+  }
+}

--- a/boundedqueue/src/test/java/io/bufferslayer/SizeFirstQueueRecyclerTest.java
+++ b/boundedqueue/src/test/java/io/bufferslayer/SizeFirstQueueRecyclerTest.java
@@ -1,0 +1,78 @@
+package io.bufferslayer;
+
+import static io.bufferslayer.TestMessage.newMessage;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+
+import io.bufferslayer.OverflowStrategy.Strategy;
+import java.util.concurrent.TimeUnit;
+import org.jdeferred.impl.DeferredObject;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Created by guohang.bao on 2017/5/4.
+ */
+public class SizeFirstQueueRecyclerTest {
+
+  SizeFirstQueueRecycler recycler = new SizeFirstQueueRecycler(1, Strategy.Fail,
+      TimeUnit.MILLISECONDS.toNanos(10));
+
+  @Before
+  public void setup() {
+    recycler.clear();
+  }
+
+  static SizeBoundedQueue newQueue() {
+    return new SizeBoundedQueue(10, Strategy.Fail);
+  }
+
+  static DeferredObject newDeferred() {
+    return new DeferredObject();
+  }
+
+  @Test
+  public void getAfterCreate() {
+    SizeBoundedQueue q = recycler.getOrCreate(Message.STRICT_ORDER);
+    assertEquals(q, recycler.getOrCreate(Message.STRICT_ORDER));
+  }
+
+  @Test
+  public void leaseBySize() {
+    SizeBoundedQueue q0 = newQueue(); // size 0
+    recycler.recycle(q0);
+
+    SizeBoundedQueue q2 = newQueue(); // size 2
+    q2.offer(newMessage(0), newDeferred());
+    q2.offer(newMessage(0), newDeferred());
+    recycler.recycle(q2);
+
+    SizeBoundedQueue q1 = newQueue(); // size 1
+    q1.offer(newMessage(0), newDeferred());
+    recycler.recycle(q1);
+
+    assertEquals(q2, recycler.lease(1, TimeUnit.MILLISECONDS));
+    assertEquals(q1, recycler.lease(1, TimeUnit.MILLISECONDS));
+    assertEquals(q0, recycler.lease(1, TimeUnit.MILLISECONDS));
+  }
+
+  @Test
+  public void keepAlive() throws InterruptedException {
+    SizeBoundedQueue q = recycler.getOrCreate(Message.STRICT_ORDER);
+    TimeUnit.MILLISECONDS.sleep(10);
+
+    recycler.shrink();
+    assertEquals(0, recycler.bySize.size());
+    assertEquals(0, recycler.keyToQueue.size());
+    assertEquals(0, recycler.keyToLastGet.size());
+    SizeBoundedQueue q1 = recycler.getOrCreate(Message.STRICT_ORDER);
+    assertNotEquals(q, q1);
+
+    TimeUnit.MILLISECONDS.sleep(10);
+    recycler.getOrCreate(Message.STRICT_ORDER);
+    assertEquals(1, recycler.bySize.size());
+    assertEquals(1, recycler.keyToQueue.size());
+    assertEquals(1, recycler.keyToLastGet.size());
+    assertEquals(q1, recycler.getOrCreate(Message.STRICT_ORDER));
+  }
+}

--- a/jdbc/src/test/java/io/bufferslayer/BatchJdbcTemplateTest.java
+++ b/jdbc/src/test/java/io/bufferslayer/BatchJdbcTemplateTest.java
@@ -171,14 +171,15 @@ public class BatchJdbcTemplateTest {
     reporter = AsyncReporter.builder(new JdbcTemplateSender(delegate))
         .pendingMaxMessages(2)
         .bufferedMaxMessages(2)
-        .flushThreadKeepalive(10, TimeUnit.SECONDS)
+        .messageTimeout(50, TimeUnit.MILLISECONDS)
+        .pendingKeepalive(10, TimeUnit.SECONDS)
         .build();
     batchJdbcTemplate = new BatchJdbcTemplate(delegate, reporter);
 
     for (int i = 0; i < 2; i++) {
       batchJdbcTemplate.update("INSERT INTO test(data, time) VALUES ('data', now())");
     }
-    assertEquals(1, reporter.flushThreadCount());
+    assertEquals(1, reporter.pendingRecycler.elements().size());
 
     Thread.sleep(1000);
     int rowCount = batchJdbcTemplate.queryForObject("SELECT COUNT(1) FROM test;", Integer.class);
@@ -190,14 +191,14 @@ public class BatchJdbcTemplateTest {
     reporter = AsyncReporter.builder(new JdbcTemplateSender(delegate))
         .pendingMaxMessages(2)
         .bufferedMaxMessages(2)
-        .flushThreadKeepalive(10, TimeUnit.SECONDS)
+        .pendingKeepalive(10, TimeUnit.SECONDS)
         .build();
     batchJdbcTemplate = new BatchJdbcTemplate(delegate, reporter);
 
     for (int i = 0; i < 2; i++) {
       batchJdbcTemplate.update(INSERTION, new Object[]{randomString(), new Date()});
     }
-    assertEquals(1, reporter.flushThreadCount());
+    assertEquals(1, reporter.pendingRecycler.elements().size());
   }
 
   @Test
@@ -205,13 +206,13 @@ public class BatchJdbcTemplateTest {
     reporter = AsyncReporter.builder(new JdbcTemplateSender(delegate))
         .pendingMaxMessages(2)
         .bufferedMaxMessages(2)
-        .flushThreadKeepalive(10, TimeUnit.SECONDS)
+        .pendingKeepalive(10, TimeUnit.SECONDS)
         .build();
     batchJdbcTemplate = new BatchJdbcTemplate(delegate, reporter);
 
     batchJdbcTemplate.update(INSERTION, new Object[]{randomString(), new Date()});
     batchJdbcTemplate.update(MODIFICATION, new Object[]{randomString()});
-    assertEquals(2, reporter.flushThreadCount());
+    assertEquals(2, reporter.pendingRecycler.elements().size());
   }
 
   @Test


### PR DESCRIPTION
- Introduce a `SizeFirstQueueRecycler` to manage queue's lifecycle.
- You can configure flush thread count now. So flush thread will lease queue from recycler.
- As flush thread count is fixed now, logging it at fixed rate is redundant, so removed.