### PR TITLE
Lazy initializing flush threads

### DIFF
--- a/benchmark/src/main/java/io/bufferslayer/AsyncReporterBenchmark.java
+++ b/benchmark/src/main/java/io/bufferslayer/AsyncReporterBenchmark.java
@@ -21,7 +21,7 @@ import org.openjdk.jmh.runner.options.Options;
 import org.openjdk.jmh.runner.options.OptionsBuilder;
 
 /**
- * Created by guohang.bao on 2017/3/16.
+ * Created by tramchamploo on 2017/3/16.
  */
 @Measurement(iterations = 5, time = 1)
 @Warmup(iterations = 10, time = 1)

--- a/benchmark/src/main/java/io/bufferslayer/BatchedJdbcTemplateBenchmark.java
+++ b/benchmark/src/main/java/io/bufferslayer/BatchedJdbcTemplateBenchmark.java
@@ -28,7 +28,7 @@ import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.datasource.DriverManagerDataSource;
 
 /**
- * Created by guohang.bao on 2017/3/16.
+ * Created by tramchamploo on 2017/3/16.
  */
 @Measurement(iterations = 5, time = 1)
 @Warmup(iterations = 3, time = 1)

--- a/benchmark/src/main/java/io/bufferslayer/NoopSender.java
+++ b/benchmark/src/main/java/io/bufferslayer/NoopSender.java
@@ -5,7 +5,7 @@ import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
- * Created by guohang.bao on 2017/3/27.
+ * Created by tramchamploo on 2017/3/27.
  */
 public class NoopSender implements Sender {
 

--- a/benchmark/src/main/java/io/bufferslayer/SizeBoundedQueueBenchmark.java
+++ b/benchmark/src/main/java/io/bufferslayer/SizeBoundedQueueBenchmark.java
@@ -23,7 +23,7 @@ import org.openjdk.jmh.runner.options.Options;
 import org.openjdk.jmh.runner.options.OptionsBuilder;
 
 /**
- * Created by guohang.bao on 2017/3/16.
+ * Created by tramchamploo on 2017/3/16.
  */
 @Measurement(iterations = 5, time = 1)
 @Warmup(iterations = 10, time = 1)

--- a/benchmark/src/main/java/io/bufferslayer/TimeUsedComparison.java
+++ b/benchmark/src/main/java/io/bufferslayer/TimeUsedComparison.java
@@ -11,7 +11,7 @@ import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.datasource.DriverManagerDataSource;
 
 /**
- * Created by guohang.bao on 2017/3/30.
+ * Created by tramchamploo on 2017/3/30.
  */
 public class TimeUsedComparison {
 

--- a/boundedqueue/src/main/java/io/bufferslayer/AsyncSender.java
+++ b/boundedqueue/src/main/java/io/bufferslayer/AsyncSender.java
@@ -8,7 +8,7 @@ import org.jdeferred.multiple.MultipleResults;
 import org.jdeferred.multiple.OneReject;
 
 /**
- * Created by guohang.bao on 2017/4/14.
+ * Created by tramchamploo on 2017/4/14.
  */
 public interface AsyncSender<M extends Message> extends Component {
 

--- a/boundedqueue/src/main/java/io/bufferslayer/BufferOverflowException.java
+++ b/boundedqueue/src/main/java/io/bufferslayer/BufferOverflowException.java
@@ -1,7 +1,7 @@
 package io.bufferslayer;
 
 /**
- * Created by guohang.bao on 2017/4/10.
+ * Created by tramchamploo on 2017/4/10.
  */
 public class BufferOverflowException extends RuntimeException {
 

--- a/boundedqueue/src/main/java/io/bufferslayer/DefaultSenderToAsyncSenderAdaptor.java
+++ b/boundedqueue/src/main/java/io/bufferslayer/DefaultSenderToAsyncSenderAdaptor.java
@@ -7,7 +7,7 @@ import java.util.List;
 import java.util.concurrent.Executor;
 
 /**
- * Created by guohang.bao on 2017/4/14.
+ * Created by tramchamploo on 2017/4/14.
  */
 final class DefaultSenderToAsyncSenderAdaptor<M extends Message, R> extends
     SenderToAsyncSenderAdaptor<M, R> {

--- a/boundedqueue/src/main/java/io/bufferslayer/DeferredHolder.java
+++ b/boundedqueue/src/main/java/io/bufferslayer/DeferredHolder.java
@@ -6,7 +6,7 @@ import org.jdeferred.Deferred;
 import org.jdeferred.impl.DeferredObject;
 
 /**
- * Created by guohang.bao on 2017/4/12.
+ * Created by tramchamploo on 2017/4/12.
  * Maintain a mapping from messageId to Defferred
  */
 class DeferredHolder {

--- a/boundedqueue/src/main/java/io/bufferslayer/DeferredUtil.java
+++ b/boundedqueue/src/main/java/io/bufferslayer/DeferredUtil.java
@@ -7,7 +7,7 @@ import org.jdeferred.multiple.MultipleResults;
 import org.jdeferred.multiple.OneResult;
 
 /**
- * Created by guohang.bao on 2017/4/14.
+ * Created by tramchamploo on 2017/4/14.
  */
 class DeferredUtil {
 

--- a/boundedqueue/src/main/java/io/bufferslayer/MessageDroppedException.java
+++ b/boundedqueue/src/main/java/io/bufferslayer/MessageDroppedException.java
@@ -6,7 +6,7 @@ import io.bufferslayer.OverflowStrategy.Strategy;
 import java.util.List;
 
 /**
- * Created by guohang.bao on 2017/4/12.
+ * Created by tramchamploo on 2017/4/12.
  * Exception raised when deferred is rejected.
  */
 public class MessageDroppedException extends RuntimeException {

--- a/boundedqueue/src/main/java/io/bufferslayer/OverflowStrategy.java
+++ b/boundedqueue/src/main/java/io/bufferslayer/OverflowStrategy.java
@@ -8,7 +8,7 @@ import static io.bufferslayer.OverflowStrategy.Strategy.DropTail;
 import static io.bufferslayer.OverflowStrategy.Strategy.Fail;
 
 /**
- * Created by guohang.bao on 2017/4/10.
+ * Created by tramchamploo on 2017/4/10.
  * Represents a strategy that decides how to deal with a buffer that is full but is
  * about to receive a new element.
  * This is inspired by Akka stream.

--- a/boundedqueue/src/main/java/io/bufferslayer/QueueRecycler.java
+++ b/boundedqueue/src/main/java/io/bufferslayer/QueueRecycler.java
@@ -6,7 +6,7 @@ import java.util.List;
 import java.util.concurrent.TimeUnit;
 
 /**
- * Created by guohang.bao on 2017/5/4.
+ * Created by tramchamploo on 2017/5/4.
  * A recycler that manages {@link SizeBoundedQueue}'s lifecycle
  */
 public interface QueueRecycler {

--- a/boundedqueue/src/main/java/io/bufferslayer/ReporterProperties.java
+++ b/boundedqueue/src/main/java/io/bufferslayer/ReporterProperties.java
@@ -9,7 +9,7 @@ import java.util.concurrent.Executor;
 import java.util.concurrent.TimeUnit;
 
 /**
- * Created by guohang.bao on 2017/3/16.
+ * Created by tramchamploo on 2017/3/16.
  */
 public class ReporterProperties {
 

--- a/boundedqueue/src/main/java/io/bufferslayer/RoundRobinQueueRecycler.java
+++ b/boundedqueue/src/main/java/io/bufferslayer/RoundRobinQueueRecycler.java
@@ -14,7 +14,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Created by guohang.bao on 2017/5/4.
+ * Created by tramchamploo on 2017/5/4.
  */
 final class RoundRobinQueueRecycler implements QueueRecycler {
 

--- a/boundedqueue/src/main/java/io/bufferslayer/SenderToAsyncSenderAdaptor.java
+++ b/boundedqueue/src/main/java/io/bufferslayer/SenderToAsyncSenderAdaptor.java
@@ -17,7 +17,7 @@ import org.jdeferred.multiple.MultipleResults;
 import org.jdeferred.multiple.OneReject;
 
 /**
- * Created by guohang.bao on 2017/4/14.
+ * Created by tramchamploo on 2017/4/14.
  */
 abstract class SenderToAsyncSenderAdaptor<M extends Message, R> implements AsyncSender<M> {
 

--- a/boundedqueue/src/main/java/io/bufferslayer/SizeBoundedQueue.java
+++ b/boundedqueue/src/main/java/io/bufferslayer/SizeBoundedQueue.java
@@ -16,7 +16,7 @@ import java.util.concurrent.locks.ReentrantLock;
 import org.jdeferred.Deferred;
 
 /**
- * Created by guohang.bao on 2017/2/28.
+ * Created by tramchamploo on 2017/2/28.
  *
  * Adapted from zipkin
  * Multi-producer, multi-consumer queue that is bounded by count.

--- a/boundedqueue/src/test/java/io/bufferslayer/AsyncReporterTest.java
+++ b/boundedqueue/src/test/java/io/bufferslayer/AsyncReporterTest.java
@@ -16,7 +16,7 @@ import org.junit.After;
 import org.junit.Test;
 
 /**
- * Created by guohang.bao on 2017/3/14.
+ * Created by tramchamploo on 2017/3/14.
  */
 public class AsyncReporterTest {
 
@@ -325,5 +325,17 @@ public class AsyncReporterTest {
     Thread.sleep(10);
     reporter.flush();
     assertEquals(0, metrics.queuedMessages.size());
+  }
+
+  @Test
+  public void lazyInitFlushThreads() throws InterruptedException {
+    FakeSender sender = new FakeSender();
+    reporter = AsyncReporter.builder(sender).flushThreadCount(1).build();
+
+    assertEquals(0, reporter.flushThreads.size());
+    reporter.report(newMessage(0));
+    assertEquals(1, reporter.flushThreads.size());
+    reporter.report(newMessage(0));
+    assertEquals(1, reporter.flushThreads.size());
   }
 }

--- a/boundedqueue/src/test/java/io/bufferslayer/DefaultSenderToAsnycSenderAdaptorTest.java
+++ b/boundedqueue/src/test/java/io/bufferslayer/DefaultSenderToAsnycSenderAdaptorTest.java
@@ -11,7 +11,7 @@ import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
 /**
- * Created by guohang.bao on 2017/4/17.
+ * Created by tramchamploo on 2017/4/17.
  */
 public class DefaultSenderToAsnycSenderAdaptorTest {
 

--- a/boundedqueue/src/test/java/io/bufferslayer/FakeSender.java
+++ b/boundedqueue/src/test/java/io/bufferslayer/FakeSender.java
@@ -7,7 +7,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Consumer;
 
 /**
- * Created by guohang.bao on 2017/3/14.
+ * Created by tramchamploo on 2017/3/14.
  */
 public class FakeSender implements Sender<TestMessage, Integer> {
 

--- a/boundedqueue/src/test/java/io/bufferslayer/OverflowStrategyTest.java
+++ b/boundedqueue/src/test/java/io/bufferslayer/OverflowStrategyTest.java
@@ -13,7 +13,7 @@ import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
 /**
- * Created by guohang.bao on 2017/4/18.
+ * Created by tramchamploo on 2017/4/18.
  */
 public class OverflowStrategyTest {
 

--- a/boundedqueue/src/test/java/io/bufferslayer/RoundRobinQueueRecyclerTest.java
+++ b/boundedqueue/src/test/java/io/bufferslayer/RoundRobinQueueRecyclerTest.java
@@ -15,7 +15,7 @@ import org.junit.Before;
 import org.junit.Test;
 
 /**
- * Created by guohang.bao on 2017/5/4.
+ * Created by tramchamploo on 2017/5/4.
  */
 @SuppressWarnings("unchecked")
 public class RoundRobinQueueRecyclerTest {

--- a/boundedqueue/src/test/java/io/bufferslayer/SizeBoundedQueueTest.java
+++ b/boundedqueue/src/test/java/io/bufferslayer/SizeBoundedQueueTest.java
@@ -18,7 +18,7 @@ import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
 /**
- * Created by guohang.bao on 2017/3/14.
+ * Created by tramchamploo on 2017/3/14.
  */
 public class SizeBoundedQueueTest {
 

--- a/boundedqueue/src/test/java/io/bufferslayer/TestMessage.java
+++ b/boundedqueue/src/test/java/io/bufferslayer/TestMessage.java
@@ -1,7 +1,7 @@
 package io.bufferslayer;
 
 /**
- * Created by guohang.bao on 2017/3/14.
+ * Created by tramchamploo on 2017/3/14.
  */
 public class TestMessage extends Message {
 

--- a/core/src/main/java/io/bufferslayer/HttpReporterMetricsExporter.java
+++ b/core/src/main/java/io/bufferslayer/HttpReporterMetricsExporter.java
@@ -6,7 +6,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Created by guohang.bao on 2017/3/16.
+ * Created by tramchamploo on 2017/3/16.
  * A simple metrics viewer on port 15090
  */
 public class HttpReporterMetricsExporter extends ReporterMetricsExporter {

--- a/core/src/main/java/io/bufferslayer/InMemoryReporterMetrics.java
+++ b/core/src/main/java/io/bufferslayer/InMemoryReporterMetrics.java
@@ -7,7 +7,7 @@ import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 
 /**
- * Created by guohang.bao on 2017/2/28.
+ * Created by tramchamploo on 2017/2/28.
  */
 public class InMemoryReporterMetrics extends ReporterMetrics {
 

--- a/core/src/main/java/io/bufferslayer/LogReporterMetricsExporter.java
+++ b/core/src/main/java/io/bufferslayer/LogReporterMetricsExporter.java
@@ -7,7 +7,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Created by guohang.bao on 2017/3/16.
+ * Created by tramchamploo on 2017/3/16.
  */
 public class LogReporterMetricsExporter extends ReporterMetricsExporter {
 

--- a/core/src/main/java/io/bufferslayer/Message.java
+++ b/core/src/main/java/io/bufferslayer/Message.java
@@ -4,7 +4,7 @@ import java.io.Serializable;
 import java.util.concurrent.atomic.AtomicLong;
 
 /**
- * Created by guohang.bao on 2017/3/3.
+ * Created by tramchamploo on 2017/3/3.
  * Message can be send to reporter, could be a sql or a hbase query
  */
 public abstract class Message implements Serializable {

--- a/core/src/main/java/io/bufferslayer/Reporter.java
+++ b/core/src/main/java/io/bufferslayer/Reporter.java
@@ -3,7 +3,7 @@ package io.bufferslayer;
 import org.jdeferred.Promise;
 
 /**
- * Created by guohang.bao on 2017/2/27.
+ * Created by tramchamploo on 2017/2/27.
  */
 public interface Reporter {
 

--- a/core/src/main/java/io/bufferslayer/ReporterMetrics.java
+++ b/core/src/main/java/io/bufferslayer/ReporterMetrics.java
@@ -3,8 +3,7 @@ package io.bufferslayer;
 import io.bufferslayer.Message.MessageKey;
 
 /**
- * Created by guohang.bao on 2017/2/27.
- * @param <QueueKey> key for updating queued messages
+ * Created by tramchamploo on 2017/2/27.
  */
 public abstract class ReporterMetrics {
 

--- a/core/src/main/java/io/bufferslayer/ReporterMetricsExporter.java
+++ b/core/src/main/java/io/bufferslayer/ReporterMetricsExporter.java
@@ -3,7 +3,7 @@ package io.bufferslayer;
 import java.io.Closeable;
 
 /**
- * Created by guohang.bao on 2017/3/16.
+ * Created by tramchamploo on 2017/3/16.
  */
 public abstract class ReporterMetricsExporter implements Closeable {
 

--- a/core/src/main/java/io/bufferslayer/Sender.java
+++ b/core/src/main/java/io/bufferslayer/Sender.java
@@ -4,7 +4,7 @@ import io.bufferslayer.internal.Component;
 import java.util.List;
 
 /**
- * Created by guohang.bao on 2017/2/27.
+ * Created by tramchamploo on 2017/2/27.
  * @param <M> Type of Message
  * @param <R> Type of return value
  */

--- a/core/src/main/java/io/bufferslayer/internal/Component.java
+++ b/core/src/main/java/io/bufferslayer/internal/Component.java
@@ -4,9 +4,8 @@ import com.google.common.base.Preconditions;
 import java.io.Closeable;
 import java.io.IOException;
 
-
 /**
- * Created by guohang.bao on 2017/2/27.
+ * Created by tramchamploo on 2017/2/27.
  * Adapted from zipkin
  */
 public interface Component extends Closeable {

--- a/jdbc/src/main/java/io/bufferslayer/ArgPreparedStatementSetter.java
+++ b/jdbc/src/main/java/io/bufferslayer/ArgPreparedStatementSetter.java
@@ -24,7 +24,7 @@ class ArgPreparedStatementSetter implements PreparedStatementSetter, ParameterDi
    *
    * @param args the arguments to set
    */
-  public ArgPreparedStatementSetter(Object[] args) {
+  ArgPreparedStatementSetter(Object[] args) {
     this.args = args;
   }
 

--- a/jdbc/src/main/java/io/bufferslayer/ArgTypePreparedStatementSetter.java
+++ b/jdbc/src/main/java/io/bufferslayer/ArgTypePreparedStatementSetter.java
@@ -30,7 +30,7 @@ class ArgTypePreparedStatementSetter implements PreparedStatementSetter, Paramet
    * @param args the arguments to set
    * @param argTypes the corresponding SQL types of the arguments
    */
-  public ArgTypePreparedStatementSetter(Object[] args, int[] argTypes) {
+  ArgTypePreparedStatementSetter(Object[] args, int[] argTypes) {
     if ((args != null && argTypes == null) || (args == null && argTypes != null) ||
         (args != null && args.length != argTypes.length)) {
       throw new InvalidDataAccessApiUsageException("args and argTypes parameters must match");

--- a/jdbc/src/main/java/io/bufferslayer/BatchJdbcTemplate.java
+++ b/jdbc/src/main/java/io/bufferslayer/BatchJdbcTemplate.java
@@ -29,7 +29,7 @@ import org.springframework.jdbc.support.nativejdbc.NativeJdbcExtractor;
 import org.springframework.jdbc.support.rowset.SqlRowSet;
 
 /**
- * Created by guohang.bao on 2017/3/3.
+ * Created by tramchamploo on 2017/3/3.
  */
 public class BatchJdbcTemplate {
 

--- a/jdbc/src/main/java/io/bufferslayer/JdbcTemplateSender.java
+++ b/jdbc/src/main/java/io/bufferslayer/JdbcTemplateSender.java
@@ -11,7 +11,7 @@ import org.springframework.jdbc.core.BatchPreparedStatementSetter;
 import org.springframework.jdbc.core.JdbcTemplate;
 
 /**
- * Created by guohang.bao on 2017/2/27.
+ * Created by tramchamploo on 2017/2/27.
  */
 final class JdbcTemplateSender implements Sender<Sql, Integer> {
 

--- a/jdbc/src/main/java/io/bufferslayer/Sql.java
+++ b/jdbc/src/main/java/io/bufferslayer/Sql.java
@@ -5,7 +5,7 @@ import java.util.Arrays;
 import org.springframework.jdbc.core.PreparedStatementSetter;
 
 /**
- * Created by guohang.bao on 2017/2/27.
+ * Created by tramchamploo on 2017/2/27.
  * Represent sql to be buffered
  */
 final class Sql extends Message {
@@ -46,7 +46,7 @@ final class Sql extends Message {
     return "sql: " + sql;
   }
 
-  public static final class Builder {
+  static final class Builder {
 
     private String sql;
     private PreparedStatementSetter preparedStatementSetter;

--- a/jdbc/src/test/java/io/bufferslayer/BatchJdbcTemplateTest.java
+++ b/jdbc/src/test/java/io/bufferslayer/BatchJdbcTemplateTest.java
@@ -25,7 +25,7 @@ import org.springframework.jdbc.core.SqlParameter;
 import org.springframework.jdbc.datasource.DriverManagerDataSource;
 
 /**
- * Created by guohang.bao on 2017/3/29.
+ * Created by tramchamploo on 2017/3/29.
  */
 public class BatchJdbcTemplateTest {
 

--- a/jdbc/src/test/java/io/bufferslayer/SenderProxy.java
+++ b/jdbc/src/test/java/io/bufferslayer/SenderProxy.java
@@ -5,7 +5,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Consumer;
 
 /**
- * Created by guohang.bao on 2017/3/29.
+ * Created by tramchamploo on 2017/3/29.
  */
 public class SenderProxy implements Sender<Sql, Integer> {
 


### PR DESCRIPTION
Some users may create `AsyncReporter` but not report any messages, this leads to unnecessary load on cpu.  Lazy initialization solves this.