### PR TITLE
Add an option for lock-free message reporting

### DIFF
--- a/benchmark/src/main/java/io/github/tramchamploo/bufferslayer/BlockingSizeBoundedQueueBenchmark.java
+++ b/benchmark/src/main/java/io/github/tramchamploo/bufferslayer/BlockingSizeBoundedQueueBenchmark.java
@@ -1,5 +1,7 @@
 package io.github.tramchamploo.bufferslayer;
 
+import io.github.tramchamploo.bufferslayer.Message.MessageKey;
+import io.github.tramchamploo.bufferslayer.OverflowStrategy.Strategy;
 import java.util.concurrent.TimeUnit;
 import org.openjdk.jmh.annotations.BenchmarkMode;
 import org.openjdk.jmh.annotations.Fork;
@@ -20,26 +22,16 @@ import org.openjdk.jmh.runner.options.OptionsBuilder;
 @BenchmarkMode(Mode.Throughput)
 @OutputTimeUnit(TimeUnit.SECONDS)
 @State(Scope.Group)
-public class AsyncReporterBenchmark extends AbstractReporterBenchmark {
+public class BlockingSizeBoundedQueueBenchmark extends AbstractSizeBoundedQueueBenchmark {
 
   @Override
-  protected Reporter<Message, ?> getReporter() {
-    return AsyncReporter.builder(sender)
-        .pendingMaxMessages(100)
-        .totalQueuedMessages(100)
-        .metrics(metrics)
-        .messageTimeout(10, TimeUnit.MILLISECONDS)
-        .build();
-  }
-
-  @Override
-  protected void doClear() {
-    ((AsyncReporter) reporter).clearPendings();
+  protected AbstractSizeBoundedQueue newQueue(int maxSize, Strategy strategy, MessageKey key) {
+    return new BlockingSizeBoundedQueue(maxSize, strategy, key);
   }
 
   public static void main(String[] args) throws RunnerException {
     Options opt = new OptionsBuilder()
-        .include(".*" + AsyncReporterBenchmark.class.getSimpleName() + ".*")
+        .include(".*" + BlockingSizeBoundedQueueBenchmark.class.getSimpleName() + ".*")
         .build();
 
     new Runner(opt).run();

--- a/benchmark/src/main/java/io/github/tramchamploo/bufferslayer/ConcurrentSizeBoundedQueueBenchmark.java
+++ b/benchmark/src/main/java/io/github/tramchamploo/bufferslayer/ConcurrentSizeBoundedQueueBenchmark.java
@@ -1,5 +1,7 @@
 package io.github.tramchamploo.bufferslayer;
 
+import io.github.tramchamploo.bufferslayer.Message.MessageKey;
+import io.github.tramchamploo.bufferslayer.OverflowStrategy.Strategy;
 import java.util.concurrent.TimeUnit;
 import org.openjdk.jmh.annotations.BenchmarkMode;
 import org.openjdk.jmh.annotations.Fork;
@@ -20,26 +22,16 @@ import org.openjdk.jmh.runner.options.OptionsBuilder;
 @BenchmarkMode(Mode.Throughput)
 @OutputTimeUnit(TimeUnit.SECONDS)
 @State(Scope.Group)
-public class AsyncReporterBenchmark extends AbstractReporterBenchmark {
+public class ConcurrentSizeBoundedQueueBenchmark extends AbstractSizeBoundedQueueBenchmark {
 
   @Override
-  protected Reporter<Message, ?> getReporter() {
-    return AsyncReporter.builder(sender)
-        .pendingMaxMessages(100)
-        .totalQueuedMessages(100)
-        .metrics(metrics)
-        .messageTimeout(10, TimeUnit.MILLISECONDS)
-        .build();
-  }
-
-  @Override
-  protected void doClear() {
-    ((AsyncReporter) reporter).clearPendings();
+  protected AbstractSizeBoundedQueue newQueue(int maxSize, Strategy strategy, MessageKey key) {
+    return new ConcurrentSizeBoundedQueue(maxSize, strategy, key);
   }
 
   public static void main(String[] args) throws RunnerException {
     Options opt = new OptionsBuilder()
-        .include(".*" + AsyncReporterBenchmark.class.getSimpleName() + ".*")
+        .include(".*" + ConcurrentSizeBoundedQueueBenchmark.class.getSimpleName() + ".*")
         .build();
 
     new Runner(opt).run();

--- a/benchmark/src/main/java/io/github/tramchamploo/bufferslayer/RxReporterBenchmark.java
+++ b/benchmark/src/main/java/io/github/tramchamploo/bufferslayer/RxReporterBenchmark.java
@@ -26,9 +26,9 @@ public class RxReporterBenchmark extends AbstractReporterBenchmark {
   @Override
   protected Reporter getReporter() {
     return RxReporter.builder(sender)
-        .pendingMaxMessages(100_000)
+        .pendingMaxMessages(100)
         .metrics(metrics)
-        .messageTimeout(1000, TimeUnit.NANOSECONDS)
+        .messageTimeout(10, TimeUnit.MILLISECONDS)
         .build();
   }
 

--- a/boundedqueue/src/main/java/io/github/tramchamploo/bufferslayer/AbstractSizeBoundedQueue.java
+++ b/boundedqueue/src/main/java/io/github/tramchamploo/bufferslayer/AbstractSizeBoundedQueue.java
@@ -1,0 +1,85 @@
+package io.github.tramchamploo.bufferslayer;
+
+import io.github.tramchamploo.bufferslayer.Message.MessageKey;
+import io.github.tramchamploo.bufferslayer.internal.MessagePromise;
+
+/**
+ * A thread-safe queue that could be blocking or non-blocking
+ *
+ * @see BlockingSizeBoundedQueue
+ * @see ConcurrentSizeBoundedQueue
+ */
+abstract class AbstractSizeBoundedQueue {
+
+  interface Consumer {
+
+    /**
+     * Returns true if it accepted the next element
+     */
+    boolean accept(MessagePromise<?> next);
+  }
+
+  // Flag indicates if this queue's size exceeds bufferedMaxMessages and ready to be drained
+  volatile boolean ready = false;
+
+  private volatile long lastAccessNanos = System.nanoTime();
+
+  final int maxSize;
+  final MessageKey key;
+  // Set promise success if true, only used in benchmark
+  boolean _benchmark = false;
+
+  AbstractSizeBoundedQueue(int maxSize, MessageKey key) {
+    this.maxSize = maxSize;
+    this.key = key;
+  }
+
+  /**
+   * Notify deferred if the element could be added or reject if it could not due to its
+   * {@link OverflowStrategy.Strategy}.
+   */
+  abstract void offer(MessagePromise<?> promise);
+
+  /**
+   * Drain all elements of this queue to a consumer
+   */
+  abstract int drainTo(Consumer consumer);
+
+  /**
+   * Clears the queue unconditionally and returns count of elements cleared.
+   */
+  abstract int clear();
+
+  /**
+   * Return the size of this queue
+   */
+  abstract int size();
+
+  /**
+   * Return {@code true} if empty else {@code false}
+   */
+  abstract boolean isEmpty();
+
+  /**
+   * set last access time to now
+   */
+  void recordAccess() {
+    if (key != Message.SINGLE_KEY) {
+      lastAccessNanos = System.nanoTime();
+    }
+  }
+
+  /**
+   * last time of this key accessed in nanoseconds
+   */
+  long lastAccessNanos() {
+    return key == Message.SINGLE_KEY ? Long.MAX_VALUE : lastAccessNanos;
+  }
+
+  /**
+   * Set the benchmark mode
+   */
+  void _setBenchmarkMode(boolean benchmark) {
+    _benchmark = benchmark;
+  }
+}

--- a/boundedqueue/src/main/java/io/github/tramchamploo/bufferslayer/BlockingSizeBoundedQueueFactory.java
+++ b/boundedqueue/src/main/java/io/github/tramchamploo/bufferslayer/BlockingSizeBoundedQueueFactory.java
@@ -1,0 +1,26 @@
+package io.github.tramchamploo.bufferslayer;
+
+import io.github.tramchamploo.bufferslayer.Message.MessageKey;
+import io.github.tramchamploo.bufferslayer.OverflowStrategy.Strategy;
+
+/**
+ * Factory for {@link BlockingSizeBoundedQueue}
+ */
+public final class BlockingSizeBoundedQueueFactory extends SizeBoundedQueueFactory {
+
+  @Override
+  protected boolean isAvailable() {
+    return true;
+  }
+
+  @Override
+  protected int priority() {
+    return 5;
+  }
+
+  @Override
+  protected AbstractSizeBoundedQueue newQueue(int maxSize, Strategy overflowStrategy,
+      MessageKey key) {
+    return new BlockingSizeBoundedQueue(maxSize, overflowStrategy, key);
+  }
+}

--- a/boundedqueue/src/main/java/io/github/tramchamploo/bufferslayer/Buffer.java
+++ b/boundedqueue/src/main/java/io/github/tramchamploo/bufferslayer/Buffer.java
@@ -10,7 +10,7 @@ import java.util.List;
 /**
  * A buffer that gathers messages which will be sent in the same batch later
  */
-final class Buffer implements SizeBoundedQueue.Consumer {
+final class Buffer implements AbstractSizeBoundedQueue.Consumer {
 
   private final int maxSize;
   private final boolean onlyAcceptSame;

--- a/boundedqueue/src/main/java/io/github/tramchamploo/bufferslayer/ConcurrentSizeBoundedQueue.java
+++ b/boundedqueue/src/main/java/io/github/tramchamploo/bufferslayer/ConcurrentSizeBoundedQueue.java
@@ -1,0 +1,219 @@
+package io.github.tramchamploo.bufferslayer;
+
+import static io.github.tramchamploo.bufferslayer.MessageDroppedException.dropped;
+import static io.github.tramchamploo.bufferslayer.OverflowStrategy.Strategy.Block;
+import static io.github.tramchamploo.bufferslayer.OverflowStrategy.Strategy.DropBuffer;
+import static io.github.tramchamploo.bufferslayer.OverflowStrategy.Strategy.DropHead;
+import static io.github.tramchamploo.bufferslayer.OverflowStrategy.Strategy.DropNew;
+import static io.github.tramchamploo.bufferslayer.OverflowStrategy.Strategy.DropTail;
+
+import io.github.tramchamploo.bufferslayer.Message.MessageKey;
+import io.github.tramchamploo.bufferslayer.OverflowStrategy.Strategy;
+import io.github.tramchamploo.bufferslayer.internal.MessagePromise;
+import io.github.tramchamploo.bufferslayer.internal.Promises;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.concurrent.ConcurrentLinkedDeque;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.locks.Condition;
+import java.util.concurrent.locks.ReentrantLock;
+
+/**
+ * This use {@link java.util.concurrent.ConcurrentLinkedDeque} to implement a lock-free queue
+ */
+final class ConcurrentSizeBoundedQueue extends AbstractSizeBoundedQueue {
+
+  // ConcurrentLinkedDeque.size() is an expensive operation.
+  // This size has a weak consistency on the real queue's
+  private final AtomicInteger size = new AtomicInteger();
+
+  private final Strategy overflowStrategy;
+
+  private final ConcurrentLinkedDeque<MessagePromise<?>> deque = new ConcurrentLinkedDeque<>();
+  // Lock used to block producers, only used when Block strategy is specified
+  private final ReentrantLock blocker;
+  private final Condition notFull;
+
+  ConcurrentSizeBoundedQueue(int maxSize, Strategy overflowStrategy, MessageKey key) {
+    super(maxSize, key);
+    this.overflowStrategy = overflowStrategy;
+    if (overflowStrategy == Block) {
+      blocker = new ReentrantLock();
+      notFull = blocker.newCondition();
+    } else {
+      blocker = null;
+      notFull = null;
+    }
+  }
+
+  // Used for testing
+  ConcurrentSizeBoundedQueue(int maxSize, Strategy overflowStrategy) {
+    this(maxSize, overflowStrategy, Message.SINGLE_KEY);
+  }
+
+  @Override
+  void offer(MessagePromise<?> promise) {
+    for (;;) {
+      int now = size.get();
+
+      if (now >= maxSize) {
+        switch (overflowStrategy) {
+          case DropNew:
+            // Double check if the size has been changed
+            if ((now = size.get()) >= maxSize) {
+              promise.setFailure(dropped(DropNew, promise.message()));
+              return;
+            }
+            // Continue to offer
+            break;
+
+          case DropTail:
+            if (size.compareAndSet(now, now - 1)) {
+              MessagePromise<?> tail = deque.pollLast();
+              // tail can be null if queue gets drained
+              if (tail != null)
+                tail.setFailure(dropped(DropTail, tail.message()));
+              else
+                // Reset counter
+                size.incrementAndGet();
+            }
+            // Lost CAS race to another thread
+            // Or successfully dropped tail
+            // Or tail get drained; re-read counter
+            continue;
+
+          case DropHead:
+            if (size.compareAndSet(now, now - 1)) {
+              MessagePromise<?> head = deque.pollFirst();
+              // head can be null if queue gets drained
+              if (head != null)
+                head.setFailure(dropped(DropHead, head.message()));
+              else
+                // Reset counter
+                size.incrementAndGet();
+            }
+            // Lost CAS race to another thread
+            // Or successfully dropped head
+            // Or head get drained; re-read counter
+            continue;
+
+          case DropBuffer:
+            List<MessagePromise<?>> allElements = removeAll(deque);
+            // Nodes already removed, counter definitely should follow
+            int dropped;
+            if ((dropped = allElements.size()) > 0)
+              incSize(now, -dropped);
+
+            Promises.allFail(allElements, DropBuffer);
+            continue;
+
+          case Block:
+            handleBlock();
+            continue;
+
+          case Fail:
+            // Double check if the size has been changed
+            if ((now = size.get()) >= maxSize)
+              throw new BufferOverflowException("Max size of " + maxSize + " is reached.");
+            break;
+        }
+      }
+
+      if (size.compareAndSet(now, now + 1)) {
+        deque.offer(promise);
+        return;
+      }
+      // Lost CAS race to another thread; re-read counter
+    }
+  }
+
+  private void incSize(int expected, int delta) {
+    int prev = expected;
+    while (!size.compareAndSet(prev, prev + delta)) {
+      prev = size.get();
+    }
+  }
+
+  private void handleBlock() {
+    boolean wasInterrupted = false;
+
+    blocker.lock();
+    try {
+      while (size.get() >= maxSize) {
+        try {
+          notFull.await();
+        } catch (InterruptedException e) {
+          wasInterrupted = true;
+        }
+      }
+    } finally {
+      blocker.unlock();
+    }
+
+    if (wasInterrupted) {
+      Thread.currentThread().interrupt();
+    }
+  }
+
+  private static List<MessagePromise<?>> removeAll(ConcurrentLinkedDeque<MessagePromise<?>> deque) {
+    final List<MessagePromise<?>> result = new LinkedList<>();
+    MessagePromise<?> promise;
+
+    while ((promise = deque.pollFirst()) != null) {
+      result.add(promise);
+    }
+    return result;
+  }
+
+  @Override
+  int drainTo(Consumer consumer) {
+    MessagePromise<?> promise;
+    int drained = 0;
+
+    while ((promise = deque.poll()) != null) {
+      if (!consumer.accept(promise)) {
+        // deque may have been changed since last poll, but never mind
+        deque.offerFirst(promise);
+        break;
+      }
+      drained++;
+      if (_benchmark) {
+        promise.setSuccess();
+      }
+    }
+    size.addAndGet(-drained);
+
+    // Unpark waiting threads if block strategy is applied
+    if (notFull != null && drained > 0) {
+      blocker.lock();
+      try {
+        for (int count = drained; count > 0 && blocker.hasWaiters(notFull); count--) {
+          notFull.signal();
+        }
+      } finally {
+        blocker.unlock();
+      }
+    }
+    return drained;
+  }
+
+  @Override
+  int clear() {
+    return drainTo(new Consumer() {
+      @Override
+      public boolean accept(MessagePromise<?> next) {
+        return true;
+      }
+    });
+  }
+
+  @Override
+  int size() {
+    return size.get();
+  }
+
+  @Override
+  boolean isEmpty() {
+    return deque.isEmpty();
+  }
+}

--- a/boundedqueue/src/main/java/io/github/tramchamploo/bufferslayer/ConcurrentSizeBoundedQueueFactory.java
+++ b/boundedqueue/src/main/java/io/github/tramchamploo/bufferslayer/ConcurrentSizeBoundedQueueFactory.java
@@ -1,0 +1,26 @@
+package io.github.tramchamploo.bufferslayer;
+
+import io.github.tramchamploo.bufferslayer.Message.MessageKey;
+import io.github.tramchamploo.bufferslayer.OverflowStrategy.Strategy;
+
+/**
+ * Factory for {@link ConcurrentSizeBoundedQueue}
+ */
+public final class ConcurrentSizeBoundedQueueFactory extends SizeBoundedQueueFactory {
+
+  @Override
+  protected boolean isAvailable() {
+    return true;
+  }
+
+  @Override
+  protected int priority() {
+    return 10;
+  }
+
+  @Override
+  protected AbstractSizeBoundedQueue newQueue(int maxSize, Strategy overflowStrategy,
+      MessageKey key) {
+    return new ConcurrentSizeBoundedQueue(maxSize, overflowStrategy, key);
+  }
+}

--- a/boundedqueue/src/main/java/io/github/tramchamploo/bufferslayer/FlushThreadFactory.java
+++ b/boundedqueue/src/main/java/io/github/tramchamploo/bufferslayer/FlushThreadFactory.java
@@ -28,7 +28,7 @@ class FlushThreadFactory {
     return factory.newThread(new FlushRunnable());
   }
 
-  private void reScheduleAndFlush(SizeBoundedQueue q) {
+  private void reScheduleAndFlush(AbstractSizeBoundedQueue q) {
     try {
       while (q.size() >= reporter.bufferedMaxMessages) {
         // cancel timer on the queue and reschedule
@@ -52,7 +52,7 @@ class FlushThreadFactory {
             break;
           }
           // wait when no queue is ready
-          SizeBoundedQueue q = synchronizer.poll(reporter.messageTimeoutNanos);
+          AbstractSizeBoundedQueue q = synchronizer.poll(reporter.messageTimeoutNanos);
           if (q == null) continue;
           reScheduleAndFlush(q);
         }

--- a/boundedqueue/src/main/java/io/github/tramchamploo/bufferslayer/SizeBoundedQueueFactory.java
+++ b/boundedqueue/src/main/java/io/github/tramchamploo/bufferslayer/SizeBoundedQueueFactory.java
@@ -1,0 +1,50 @@
+package io.github.tramchamploo.bufferslayer;
+
+import io.github.tramchamploo.bufferslayer.Message.MessageKey;
+import io.github.tramchamploo.bufferslayer.OverflowStrategy.Strategy;
+import java.util.ServiceConfigurationError;
+import java.util.ServiceLoader;
+
+/**
+ * Base factory for {@link AbstractSizeBoundedQueue}
+ * <p> This use {@link ServiceLoader} to find the actual factory
+ */
+public abstract class SizeBoundedQueueFactory {
+  private static final SizeBoundedQueueFactory factory =
+      load(SizeBoundedQueueFactory.class.getClassLoader());
+
+  private static final SizeBoundedQueueFactory load(ClassLoader cl) {
+    ServiceLoader<SizeBoundedQueueFactory> providers = ServiceLoader.load(SizeBoundedQueueFactory.class, cl);
+    SizeBoundedQueueFactory best = null;
+
+    for (SizeBoundedQueueFactory current : providers) {
+      if (!current.isAvailable()) {
+        continue;
+      } else if (best == null) {
+        best = current;
+      } else if (current.priority() > best.priority()) {
+        best = current;
+      }
+    }
+    return best;
+  }
+
+  public static SizeBoundedQueueFactory factory() {
+    if (factory == null) {
+      throw new ServiceConfigurationError("No functional queue factory found.");
+    }
+    return factory;
+  }
+
+  /**
+   * Return {@code true} if this factory is available else {@code false}
+   */
+  protected abstract boolean isAvailable();
+
+  /**
+   * Return priority of this factory, the higher the more possibility to be used
+   */
+  protected abstract int priority();
+
+  protected abstract AbstractSizeBoundedQueue newQueue(int maxSize, Strategy overflowStrategy, MessageKey key);
+}

--- a/boundedqueue/src/main/resources/META-INF/services/io.github.tramchamploo.bufferslayer.SizeBoundedQueueFactory
+++ b/boundedqueue/src/main/resources/META-INF/services/io.github.tramchamploo.bufferslayer.SizeBoundedQueueFactory
@@ -1,0 +1,2 @@
+io.github.tramchamploo.bufferslayer.ConcurrentSizeBoundedQueueFactory
+io.github.tramchamploo.bufferslayer.BlockingSizeBoundedQueueFactory

--- a/boundedqueue/src/test/java/io/github/tramchamploo/bufferslayer/BlockingSizeBoundedQueueTest.java
+++ b/boundedqueue/src/test/java/io/github/tramchamploo/bufferslayer/BlockingSizeBoundedQueueTest.java
@@ -1,0 +1,8 @@
+package io.github.tramchamploo.bufferslayer;
+
+public final class BlockingSizeBoundedQueueTest extends AbstractSizeBoundedQueueTest {
+
+  protected AbstractSizeBoundedQueue newQueue(OverflowStrategy.Strategy strategy) {
+    return new BlockingSizeBoundedQueue(16, strategy);
+  }
+}

--- a/boundedqueue/src/test/java/io/github/tramchamploo/bufferslayer/ConcurrentSizeBoundedQueueTest.java
+++ b/boundedqueue/src/test/java/io/github/tramchamploo/bufferslayer/ConcurrentSizeBoundedQueueTest.java
@@ -1,0 +1,8 @@
+package io.github.tramchamploo.bufferslayer;
+
+public final class ConcurrentSizeBoundedQueueTest extends AbstractSizeBoundedQueueTest {
+
+  protected AbstractSizeBoundedQueue newQueue(OverflowStrategy.Strategy strategy) {
+    return new ConcurrentSizeBoundedQueue(16, strategy);
+  }
+}

--- a/boundedqueue/src/test/java/io/github/tramchamploo/bufferslayer/QueueManagerTest.java
+++ b/boundedqueue/src/test/java/io/github/tramchamploo/bufferslayer/QueueManagerTest.java
@@ -15,9 +15,9 @@ import org.junit.Test;
 @SuppressWarnings("unchecked")
 public class QueueManagerTest {
 
-  QueueManager manager;
+  private QueueManager manager;
 
-  static MessageKey testKey() {
+  private static MessageKey testKey() {
     return new MessageKey() {
       @Override
       public int hashCode() {
@@ -44,7 +44,7 @@ public class QueueManagerTest {
   
   @Test
   public void getAfterCreate() {
-    SizeBoundedQueue q = manager.getOrCreate(testKey());
+    AbstractSizeBoundedQueue q = manager.getOrCreate(testKey());
     assertEquals(q, manager.getOrCreate(testKey()));
   }
 
@@ -54,7 +54,7 @@ public class QueueManagerTest {
     AtomicInteger callCount = new AtomicInteger();
     manager.onCreate(new Callback() {
       @Override
-      public void call(SizeBoundedQueue queue) {
+      public void call(AbstractSizeBoundedQueue queue) {
         assertEquals(testKey(), queue.key);
         callCount.incrementAndGet();
         countDown.countDown();
@@ -69,12 +69,12 @@ public class QueueManagerTest {
 
   @Test
   public void keepAlive() throws InterruptedException {
-    SizeBoundedQueue q = manager.getOrCreate(testKey());
+    AbstractSizeBoundedQueue q = manager.getOrCreate(testKey());
     TimeUnit.MILLISECONDS.sleep(10);
 
     assertEquals(testKey(), manager.shrink().get(0));
     assertEquals(0, manager.keyToQueue.size());
-    SizeBoundedQueue q1 = manager.getOrCreate(testKey());
+    AbstractSizeBoundedQueue q1 = manager.getOrCreate(testKey());
     assertNotEquals(q, q1);
 
     TimeUnit.MILLISECONDS.sleep(10);


### PR DESCRIPTION
Using Doug Lea's `ConcurrentLinkedQueue` to implement size bounded queue.
Now there are two options for message queue. So we have a factory based on `ServiceLoader` to create new queues.