### PR TITLE
Use an accumulator to record update result on queued messages.

### DIFF
--- a/boundedqueue/src/main/java/io/github/tramchamploo/bufferslayer/AsyncReporter.java
+++ b/boundedqueue/src/main/java/io/github/tramchamploo/bufferslayer/AsyncReporter.java
@@ -332,7 +332,8 @@ public class AsyncReporter<M extends Message, R> extends TimeDriven<MessageKey> 
     // Update metrics
     metrics.updateQueuedMessages(pending.key, pending.size());
     // Signal producers
-    memoryLimiter.signalAll();
+    if (!memoryLimiter.isMaximum())
+      memoryLimiter.signalAll();
 
     logWhenFailed(result);
     return result;

--- a/boundedqueue/src/main/java/io/github/tramchamploo/bufferslayer/MemoryLimiter.java
+++ b/boundedqueue/src/main/java/io/github/tramchamploo/bufferslayer/MemoryLimiter.java
@@ -20,7 +20,12 @@ abstract class MemoryLimiter {
   }
 
   /**
-   * Block threads if reach the limit until signaled
+   * Returns true if exceeds memory limit
+   */
+  abstract boolean isMaximum();
+
+  /**
+   * Block current thread if reach the limit until signaled
    */
   abstract void waitWhenMaximum();
 
@@ -41,6 +46,11 @@ abstract class MemoryLimiter {
     private DefaultMemoryLimiter(long maxMessages, ReporterMetrics metrics) {
       this.maxMessages = maxMessages;
       this.metrics = metrics;
+    }
+
+    @Override
+    boolean isMaximum() {
+      return metrics.queuedMessages() >= maxMessages;
     }
 
     @Override
@@ -69,11 +79,6 @@ abstract class MemoryLimiter {
       } finally {
         lock.unlock();
       }
-    }
-
-    private boolean isMaximum() {
-      // This may be an expensive calculation
-      return metrics.queuedMessages() >= maxMessages;
     }
   }
 }


### PR DESCRIPTION
So get will not need to do calculations in real time.

This reverts commit 25edc1b983aa433b6bd1352ea6bcb55eede2be38.