### PR TITLE
Remove from metrics should update accumulator in case of metrics leak

### DIFF
--- a/core/src/main/java/io/github/tramchamploo/bufferslayer/InMemoryReporterMetrics.java
+++ b/core/src/main/java/io/github/tramchamploo/bufferslayer/InMemoryReporterMetrics.java
@@ -97,7 +97,10 @@ public class InMemoryReporterMetrics extends ReporterMetrics {
 
   @Override
   public void removeFromQueuedMessages(MessageKey queueKey) {
-    queuedMessages.remove(queueKey);
+    AtomicLong value = queuedMessages.remove(queueKey);
+    if (value != null) {
+      queuedMessagesAccumulator.add(-value.get());
+    }
   }
 
   public void clear() {


### PR DESCRIPTION
Even though there is no such scenario at this time, when all remove calls happen when the queue is empty.